### PR TITLE
line15にてコメントを記述+clickscript.jsの修正

### DIFF
--- a/clickscript.js
+++ b/clickscript.js
@@ -1,22 +1,23 @@
 canvas = document.getElementById ('sample');
 ctx = canvas.getContext ('2d');   
 
-function draw() {
-	img = new Image();
-    img.src = "shougi.png";
-	ctx.drawImage (img , x , y);
-}
+img = new Image();
+img.src = "shougi.png";
 
 let x = 0;
 let y = 0;
 
 function onClick(e) {
+
+    // 一度描画をクリア
+    ctx.clearRect(0, 0, 600, 600);
     
     let rect = e.target.getBoundingClientRect();
-	x = e.clientX - rect.left;
-    y = e.clientY - rect.top;
+	x = e.clientX - Math.floor(rect.left);
+    y = e.clientY - Math.floor(rect.top);
     
-    draw();
+    //画像の表示位置を0ではなく画像の縦横半分の大きさを指定してクリックしたとき中央にする
+    ctx.drawImage (img , x-64 , y-64);
 
 }
 


### PR DESCRIPTION
■どういった変更か
・クリック時に画像がズレる挙動を修正
・clearRectで一回クリックする事に描画を消す
■各ファイルに対して加えた変更の概要
・onClick関数にあったdraw()関数を消してdrawImageを直接記述したら、
最初のクリックで画像が表示されるようになった。理由は不明。
・drawImageのx,y座標を画像の半分の大きさ分引いたらクリック時に丁度中央に表示されるようになった。
・座標の位置をMath.floorで計算
■参考にするべき資料のリンク
・クリック時の位置の詳しい説明
http://www.sist.ac.jp/~kanakubo/programming/canvas/canvas5.html
・座標計算や描画をクリアにする参考
https://codepen.io/utano320/pen/XXpeav?editors=1010